### PR TITLE
Avoid recreating entry_point object.

### DIFF
--- a/src/versioningit/methods.py
+++ b/src/versioningit/methods.py
@@ -15,7 +15,6 @@ else:
     from importlib_metadata import entry_points
 
 
-
 ENTRY_POINTS = entry_points()
 
 

--- a/src/versioningit/methods.py
+++ b/src/versioningit/methods.py
@@ -15,6 +15,10 @@ else:
     from importlib_metadata import entry_points
 
 
+
+ENTRY_POINTS = entry_points()
+
+
 class MethodSpec(ABC):
     """
     An abstract base class for method specifications parsed from `versioningit`
@@ -52,7 +56,7 @@ class EntryPointSpec(MethodSpec):
         """
         log.debug("Loading entry point %r in group %s", self.name, self.group)
         try:
-            ep, *_ = entry_points(group=self.group, name=self.name)
+            ep, *_ = ENTRY_POINTS.select(group=self.group, name=self.name)
         except ValueError:
             valid = [ep.name for ep in entry_points(group=self.group)]
             raise ConfigError(


### PR DESCRIPTION
Thanks for creating versioningit. I have recently migrated on of my projects from versioneer to versioningit and really enjoyed
the great options for customizability and not having to vendor code. However I did find that getting the 
version at run time is significantly more time consuming with versioningit than versioneer (400 ms vs 200 ms or so)
I did a bit of bacic profiling and found that half the time is spent on getting the version from git and half the time on 
creating entry_point objects specifically calling sorted from within `importlib.metadata`

The entry point object is created 5 times on a normal call to
get_version. In my benchmarking this costs around 40 ms each time
for a total of 200 ms. This time is dominated by sorting the entry
points. Creating the entry point object once and calling select
eliminates most of this overhead. In my usecase this is nearly a
factor of 2 speedup.

Before (0.3.1):
In [2]: %timeit versioningit.get_version(".")
386 ms +- 6.13 ms per loop (mean +- std. dev. of 7 runs, 1 loop each)

After:
In [2]: %timeit versioningit.get_version(".")
204 ms +- 4.97 ms per loop (mean +- std. dev. of 7 runs, 1 loop each)