### PR TITLE
Make `file` parameter required for "basic" write method; omit table to not write anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ v1.0.0 (in development)
     - Git 2.35's "tags" option for honoring lightweight tags is now recognized.
     - Added a dedicated error message when an invalid `%(describe)` placeholder
       is "expanded" into itself in an archive
+- The `file` parameter to the "basic" write method is now required when the
+  `[tool.versioningit.write]` table is present.  If you don't want to write the
+  version to a file, omit the table entirely.
 
 v0.3.3 (2022-02-04)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -511,23 +511,25 @@ The ``[tool.versioningit.write]`` Subtable
 ------------------------------------------
 
 The ``write`` subtable enables an optional feature, writing the final version
-to a file.  ``versioningit`` provides one ``write`` method, ``"basic"`` (the
-default), which takes the following parameters (all optional):
+to a file.  Unlike the other subtables, if the ``write`` subtable is omitted,
+the corresponding step will not be carried out.
+
+``versioningit`` provides one ``write`` method, ``"basic"`` (the default),
+which takes the following parameters:
 
 ``file`` : string
-    The path to the file to which to write the version.  This path should use
-    forward slashes (``/``) as the path separator, even on Windows.  If this
-    parameter is omitted, nothing is written anywhere.
+    *(required)* The path to the file to which to write the version.  This path
+    should use forward slashes (``/``) as the path separator, even on Windows.
 
     **Note:** This file should not be committed to version control, but it
     should be included in your project's built sdists and wheels.
 
 ``encoding`` : string
-    The encoding with which to write the file.  Defaults to UTF-8.
+    *(optional)* The encoding with which to write the file.  Defaults to UTF-8.
 
 ``template``: string
-    The content to write to the file (minus the final newline, which
-    ``versioningit`` adds automatically), as a string containing a
+    *(optional)* The content to write to the file (minus the final newline,
+    which ``versioningit`` adds automatically), as a string containing a
     ``{version}`` placeholder.  If this parameter is omitted, the default is
     determined based on the ``file`` parameter's file extension.  For ``.txt``
     files and files without an extension, the default is::

--- a/src/versioningit/basics.py
+++ b/src/versioningit/basics.py
@@ -98,11 +98,7 @@ def basic_write(
     *, project_dir: Union[str, Path], version: str, params: Dict[str, Any]
 ) -> None:
     """Implements the ``"basic"`` ``write`` method"""
-    try:
-        filename = str_guard(params.pop("file"), "tool.versioningit.write.file")
-    except KeyError:
-        log.debug("No 'file' field in tool.versioningit.write; not writing anything")
-        return
+    filename = str_guard(params.pop("file", None), "tool.versioningit.write.file")
     path = Path(project_dir, filename)
     encoding = str_guard(
         params.pop("encoding", "utf-8"), "tool.versioningit.write.encoding"

--- a/src/versioningit/core.py
+++ b/src/versioningit/core.py
@@ -58,7 +58,7 @@ class Versioningit:
     format: VersioningitMethod
 
     #: The method to call for the ``write`` step
-    write: VersioningitMethod
+    write: Optional[VersioningitMethod]
 
     @classmethod
     def from_project_dir(
@@ -110,7 +110,7 @@ class Versioningit:
             tag2version=config.tag2version.load(pdir),
             next_version=config.next_version.load(pdir),
             format=config.format.load(pdir),
-            write=config.write.load(pdir),
+            write=config.write.load(pdir) if config.write is not None else None,
         )
 
     def get_version(self) -> str:
@@ -219,7 +219,8 @@ class Versioningit:
 
     def do_write(self, version: str) -> None:
         """Run the ``write`` step"""
-        self.write(project_dir=self.project_dir, version=version)
+        if self.write is not None:
+            self.write(project_dir=self.project_dir, version=version)
 
 
 def get_version(

--- a/test/data/config/custom-methods.py
+++ b/test/data/config/custom-methods.py
@@ -22,8 +22,5 @@ cfg = Config(
         method_spec=EntryPointSpec(group="versioningit.format", name="basic"),
         params={},
     ),
-    write=ConfigSection(
-        method_spec=EntryPointSpec(group="versioningit.write", name="basic"),
-        params={},
-    ),
+    write=None,
 )

--- a/test/data/config/custom-paramless.py
+++ b/test/data/config/custom-paramless.py
@@ -22,8 +22,5 @@ cfg = Config(
         method_spec=EntryPointSpec(group="versioningit.format", name="basic"),
         params={},
     ),
-    write=ConfigSection(
-        method_spec=EntryPointSpec(group="versioningit.write", name="basic"),
-        params={},
-    ),
+    write=None,
 )

--- a/test/data/config/empty.py
+++ b/test/data/config/empty.py
@@ -18,8 +18,5 @@ cfg = Config(
         method_spec=EntryPointSpec(group="versioningit.format", name="basic"),
         params={},
     ),
-    write=ConfigSection(
-        method_spec=EntryPointSpec(group="versioningit.write", name="basic"),
-        params={},
-    ),
+    write=None,
 )

--- a/test/data/config/paramless.py
+++ b/test/data/config/paramless.py
@@ -18,8 +18,5 @@ cfg = Config(
         method_spec=EntryPointSpec(group="versioningit.format", name="basic"),
         params={},
     ),
-    write=ConfigSection(
-        method_spec=EntryPointSpec(group="versioningit.write", name="basic"),
-        params={},
-    ),
+    write=None,
 )

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -58,8 +58,5 @@ def test_parse_obj_callable_methods() -> None:
             method_spec=EntryPointSpec(group="versioningit.format", name="basic"),
             params={},
         ),
-        write=ConfigSection(
-            method_spec=EntryPointSpec(group="versioningit.write", name="basic"),
-            params={},
-        ),
+        write=None,
     )

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -29,8 +29,9 @@ def test_basic_write(
 
 
 def test_basic_write_no_file(tmp_path: Path) -> None:
-    basic_write(project_dir=tmp_path, version="1.2.3", params={})
-    assert list(tmp_path.iterdir()) == []
+    with pytest.raises(ConfigError) as excinfo:
+        basic_write(project_dir=tmp_path, version="1.2.3", params={})
+    assert str(excinfo.value) == "tool.versioningit.write.file must be set to a string"
 
 
 def test_basic_write_bad_ext(tmp_path: Path) -> None:


### PR DESCRIPTION
When the `[tool.versioningit.write]` table is present and uses the "basic" method (either explicitly or implicitly), the "file" parameter will now be required.  When the table is not present, the "write" step will be skipped entirely.