### PR TITLE
Provide example of how to convert toml to dictionary compatible with `get_version()`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -715,7 +715,16 @@ example, the following TOML configuration:
     dirty = "{version}+dirty"
     distance-dirty = "{next_version}.dev{distance}+{vcs}{rev}.dirty"
 
-corresponds to the following Python ``config`` value:
+when loaded as follows:
+
+.. code:: python
+
+    import toml
+
+    toml_load = toml.load('versioningit.toml')
+    print(get_version(config=toml_load['tool']['versioningit']))
+
+yields the following Python ``config`` value:
 
 .. code:: python
 


### PR DESCRIPTION
The docs do not show how to convert a toml file to a dictionary to provide to the `config` value of `get_version()`.

It is neither intuitive, straightforward or documented. I spent time going through the test suite and thought that perhaps `Config.parse_toml_file()` was what I should do before I figured out that you needed to navigate deeper into the dictionary before `get_version()` could consume the file converted to a dictionary.
