### PR TITLE
Avoid importing setuptools until required to speedup import

### DIFF
--- a/src/versioningit/cmdclasses.py
+++ b/src/versioningit/cmdclasses.py
@@ -1,15 +1,15 @@
 from pathlib import Path
-from typing import Any, Dict, Optional, Type
-from setuptools import Command
-from setuptools.command.build_py import build_py
-from setuptools.command.sdist import sdist
+from typing import Any, Dict, Optional, Type, TYPE_CHECKING
 from .core import run_onbuild
 from .logging import init_logging, log
 
+if TYPE_CHECKING:
+    from setuptools import Command
+
 
 def get_cmdclasses(
-    bases: Optional[Dict[str, Type[Command]]] = None
-) -> Dict[str, Type[Command]]:
+    bases: Optional[Dict[str, Type["Command"]]] = None
+) -> Dict[str, Type["Command"]]:
     """
     .. versionadded:: 1.1.0
 
@@ -26,6 +26,8 @@ def get_cmdclasses(
     ``"build_py"``.  All other classes in the input `dict` are passed through
     unchanged.
     """
+    from setuptools.command.build_py import build_py
+    from setuptools.command.sdist import sdist
 
     cmds = {} if bases is None else bases.copy()
 


### PR DESCRIPTION
Thanks for adding the cmd_classes module. I have been using it lots of places and this seems to be working great.
This change however means that doing `import versioningit` ends up importing `setuptools` which in turn imports 
`pgk_resources` Importing pkg_resources is slow since it builds a cache of all installed packages at import time 

This tries to work around that issue in setuptools by only importing setuptools when actually invoking the cmd_classes. That way you are not paying for importing setuptools if you are using versioningit to get a runtime version


Before this change

```
In [1]: %time import versioningit
CPU times: total: 1.73 s
Wall time: 2.18 s
```

After

```
In [1]: %time import versioningit
CPU times: total: 172 ms
Wall time: 286 ms
```