### PR TITLE
Add note with Caveat around conda package generation

### DIFF
--- a/docs/notes.rst
+++ b/docs/notes.rst
@@ -22,3 +22,8 @@ Restrictions & Caveats
   loads the package containing the custom method before the package is
   installed, but `importlib.metadata.version()` only works after the package is
   installed.
+
+- If you generate a conda package from your sdist (via a conda forge-feedstock)
+  you likely want to include versioningit as a ``host`` dependency in your
+  conda ``meta.yaml`` file. This is needed for the package produced from your
+  sdist to contain the correct version number in its ``dist-info``.


### PR DESCRIPTION
I recently had to track down why one of our packages did not include version numbers correctly in its conda version. It took me a while to figure out that this was caused by conda not using the build dependency in pyprojects.toml but needing versioningit at package generation time. So I figured it would be worthwhile to add a note here about that for anyone else who may hit this.