### PR TITLE
Don't "clamp" dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ v2.0.0 (in development)
   were accepted and were converted to booleans.
 - Added a `Versioningit.run()` method that returns a structure containing all
   intermediate & final values
+- "git" method: `{author_date}` and `{committer_date}` are no longer "clamped"
+  to less than or equal to `{build_date}`.  This undocumented behavior was
+  based on a misinterpretation of the `SOURCE_DATE_EPOCH` spec, and was even
+  applied when `SOURCE_DATE_EPOCH` was not set.
 
 v1.1.1 (2022-04-08)
 -------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,6 +46,11 @@ v2.0.0 (in development)
 - Added a `Versioningit.run()` method that returns a structure containing all
   intermediate & final values
 
+- "git" method: ``{author_date}`` and ``{committer_date}`` are no longer
+  "clamped" to less than or equal to ``{build_date}``.  This undocumented
+  behavior was based on a misinterpretation of the :envvar:`SOURCE_DATE_EPOCH`
+  spec, and was even applied when :envvar:`SOURCE_DATE_EPOCH` was not set.
+
 
 v1.1.1 (2022-04-08)
 -------------------

--- a/src/versioningit/git.py
+++ b/src/versioningit/git.py
@@ -235,10 +235,8 @@ def describe_git(
             "--no-pager", "show", "-s", "--format=%H%n%at%n%ct"
         ).splitlines()
         vdesc.fields["revision"] = revision
-        vdesc.fields["author_date"] = min(build_date, fromtimestamp(int(author_ts)))
-        vdesc.fields["committer_date"] = min(
-            build_date, fromtimestamp(int(committer_ts))
-        )
+        vdesc.fields["author_date"] = fromtimestamp(int(author_ts))
+        vdesc.fields["committer_date"] = fromtimestamp(int(committer_ts))
     return vdesc
 
 

--- a/test/test_methods/test_git.py
+++ b/test/test_methods/test_git.py
@@ -272,12 +272,11 @@ def test_describe_git_added_no_commits(tmp_path: Path) -> None:
 
 
 @needs_git
-def test_describe_git_clamp_dates(
+def test_describe_git_no_clamp_dates(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setenv("SOURCE_DATE_EPOCH", "1234567890")
     shutil.unpack_archive(str(DATA_DIR / "repos" / "git" / "exact.zip"), str(tmp_path))
-    dt = datetime(2009, 2, 13, 23, 31, 30, tzinfo=timezone.utc)
     assert describe_git(project_dir=tmp_path, params={}) == VCSDescription(
         tag="v0.1.0",
         state="exact",
@@ -286,9 +285,9 @@ def test_describe_git_clamp_dates(
             "distance": 0,
             "rev": "002a8cf",
             "revision": "002a8cf62e16f1b22c5869479a5ba7cac7c19fbc",
-            "author_date": dt,
-            "committer_date": dt,
-            "build_date": dt,
+            "author_date": datetime(2021, 7, 4, 4, 8, 20, tzinfo=timezone.utc),
+            "committer_date": datetime(2021, 7, 4, 4, 9, 33, tzinfo=timezone.utc),
+            "build_date": datetime(2009, 2, 13, 23, 31, 30, tzinfo=timezone.utc),
             "vcs": "g",
             "vcs_name": "git",
         },


### PR DESCRIPTION
"git" method: `{author_date}` and `{committer_date}` are no longer "clamped" to less than or equal to `{build_date}`.  This undocumented behavior was based on a misinterpretation of the `SOURCE_DATE_EPOCH` spec, and was even applied when `SOURCE_DATE_EPOCH` was not set.