### PR TITLE
Prepare plugin to upcoming PEP 660 implementation

### DIFF
--- a/src/versioningit/cmdclasses.py
+++ b/src/versioningit/cmdclasses.py
@@ -59,11 +59,13 @@ def get_cmdclasses(
     build_py_base = cmds.get("build_py", build_py)
 
     class VersioningitBuildPy(build_py_base):  # type: ignore[valid-type,misc]
+        editable_mode: bool = False
+
         def run(self) -> None:
             super().run()
             init_logging()
             template_fields = get_template_fields_from_distribution(self.distribution)
-            if template_fields is not None:
+            if not self.editable_mode and template_fields is not None:
                 PROJECT_ROOT = Path().resolve()
                 log.debug("Running onbuild step; cwd=%s", PROJECT_ROOT)
                 run_onbuild(


### PR DESCRIPTION
Hi @jwodder, I am writing this PR motivated by [this post](https://discuss.python.org/t/help-testing-pep-660-support-in-setuptools/16904/35?u=abravalheri) about the upcoming changes related to PEP 660.

I wrote some initial documentation to support build subcommands in [here](https://setuptools--3429.org.readthedocs.build/en/3429/userguide/extension.html#supporting-sdists-and-editable-installs-in-build-sub-commands), I hope that is useful.

The TLDR for why this change is necessary is the following:

- Previously the `develop` command in setuptools would only run `build_ext` and not `build_py`. `versioningit` seems to be taking advantage of this behaviour.
- In the changes I have implemented in [`pypa/setuptools@feature/pep660`](https://github.com/pypa/setuptools/blob/49e21527f9e59ca881dab360e125bb2b17280694/setuptools/command/build_py.py#L56), every build command (this generalisation includes `build_py`) has the chance to decide to run (or not) on editable installs[^1]. This happens inside the `run` method.


[^1]: The motivation for this is to improve support for custom build steps).
