### PR TITLE
Prevent run_onbuild in editable_mode and VersioningitSdist for PEP 660

### DIFF
--- a/src/versioningit/cmdclasses.py
+++ b/src/versioningit/cmdclasses.py
@@ -36,6 +36,8 @@ def get_cmdclasses(
     sdist_base = cmds.get("sdist", sdist)
 
     class VersioningitSdist(sdist_base):  # type: ignore[valid-type,misc]
+        editable_mode: bool = False
+
         def make_release_tree(self, base_dir: str, files: Any) -> None:
             super().make_release_tree(base_dir, files)
             init_logging()

--- a/src/versioningit/cmdclasses.py
+++ b/src/versioningit/cmdclasses.py
@@ -40,7 +40,7 @@ def get_cmdclasses(
             super().make_release_tree(base_dir, files)
             init_logging()
             template_fields = get_template_fields_from_distribution(self.distribution)
-            if template_fields is not None:
+            if not self.editable_mode and template_fields is not None:
                 PROJECT_ROOT = Path().resolve()
                 log.debug("Running onbuild step; cwd=%s", PROJECT_ROOT)
                 run_onbuild(


### PR DESCRIPTION
I believe this will fix the issue I mentioned in https://github.com/pypa/setuptools/issues/3501#issuecomment-1212393121.

edit: @jwodder, I have just tested this and it works :tada: