### PR TITLE
Add support to overwrite version using VERSIONINGIT_PRETEND_VERSION

### DIFF
--- a/src/versioningit/hatch.py
+++ b/src/versioningit/hatch.py
@@ -11,7 +11,7 @@ from .config import Config
 from .core import Report, Versioningit
 from .errors import NoTagError, NotSdistError, NotVersioningitError
 from .logging import init_logging, log
-from .onbuild import HatchFileProvider
+from .onbuild import HatchFileProvider, get_pretend_version
 
 
 class VersioningitSource(VersionSourceInterface):
@@ -28,6 +28,9 @@ class VersioningitSource(VersionSourceInterface):
         init_logging()
         PROJECT_ROOT = Path(self.root)
         log.info("Project dir: %s", PROJECT_ROOT)
+        pretend_version = get_pretend_version()
+        if pretend_version is not None:
+            return {"version": pretend_version}
         try:
             vgit = Versioningit.from_project_dir(PROJECT_ROOT)
             report = vgit.run(write=True, fallback=True)

--- a/src/versioningit/hook.py
+++ b/src/versioningit/hook.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 from .core import Report, Versioningit
 from .errors import NoTagError, NotSdistError, NotVersioningitError
 from .logging import init_logging, log
+from .onbuild import get_pretend_version
 
 if TYPE_CHECKING:
     from setuptools import Distribution
@@ -18,6 +19,10 @@ def setuptools_finalizer(dist: Distribution) -> None:
     # root of the source tree".
     PROJECT_ROOT = Path().resolve()
     log.info("Project dir: %s", PROJECT_ROOT)
+    pretend_version = get_pretend_version()
+    if pretend_version is not None:
+        dist.metadata.version = pretend_version
+        return
     try:
         vgit = Versioningit.from_project_dir(PROJECT_ROOT)
         report = vgit.run(write=True, fallback=True)

--- a/src/versioningit/onbuild.py
+++ b/src/versioningit/onbuild.py
@@ -366,3 +366,7 @@ def replace_version_onbuild(
             return
     with file.open("w", encoding=encoding) as fp:
         fp.writelines(lines)
+
+
+def get_pretend_version() -> str:
+    return os.getenv("VERSIONINGIT_PRETEND_VERSION")


### PR DESCRIPTION
I frequently encountered situations where I need to install a package without having the full version history available. For example when installing a single package from a large monorepo in a Docker image.

This PR adds support to overwrite the version using an environment variable `VERSIONINGIT_PRETEND_VERSION`, just like `setuptools_scm`: https://setuptools-scm.readthedocs.io/en/latest/overrides/#pretend-versions.

@jwodder, let me know what you think and then if you are open to this idea we can add docs.
