### PR TITLE
Install `editables` in test env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ minversion = 3.3.0
 [testenv]
 deps =
     build>=0.7  # Must be a version that builds wheels from sdists
+    editables
     hatchling
     setuptools>=42
     pip


### PR DESCRIPTION
So that `test_editable_mode_hatch` won't fail due to https://github.com/pypa/hatch/pull/1255