### PR TITLE
Don't crash when `log.showSignature` is set in `.gitconfig`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-v3.2.0 (in development)
+v3.1.3 (in development)
 -----------------------
 - Support Python 3.13
+- **Bugfix**: Don't crash when `log.showSignature` is set in `.gitconfig`
 
 v3.1.2 (2024-07-20)
 -------------------

--- a/src/versioningit/__init__.py
+++ b/src/versioningit/__init__.py
@@ -43,7 +43,7 @@ Visit <https://github.com/jwodder/versioningit> or
 <https://versioningit.rtfd.io> for more information.
 """
 
-__version__ = "3.2.0.dev1"
+__version__ = "3.1.3.dev1"
 __author__ = "John Thorvald Wodder II"
 __author_email__ = "versioningit@varonathe.org"
 __license__ = "MIT"

--- a/src/versioningit/git.py
+++ b/src/versioningit/git.py
@@ -236,7 +236,9 @@ def describe_git(*, project_dir: str | Path, params: dict[str, Any]) -> VCSDescr
     if "revision" not in vdesc.fields:
         revision, author_ts, committer_ts = repo.read(
             "--no-pager", "show", "-s", "--format=%H%n%at%n%ct"
-        ).splitlines()
+        ).splitlines()[-3:]
+        # [-3:] to discard possible leading GPG signature
+        # <https://github.com/jwodder/versioningit/issues/111>
         vdesc.fields["revision"] = revision
         vdesc.fields["author_date"] = fromtimestamp(int(author_ts))
         vdesc.fields["committer_date"] = fromtimestamp(int(committer_ts))


### PR DESCRIPTION
Closes #111.